### PR TITLE
feat: Feature/display content

### DIFF
--- a/bitbucket_code_insight_reports/cli.py
+++ b/bitbucket_code_insight_reports/cli.py
@@ -22,6 +22,9 @@ def parse_args(args):
     parser.add_argument(
         "--file", type=str, default=None, help="Input file for report (not required for all report types.)"
     )
+    parser.add_argument(
+        "--silent", action="store_true", default=False, help="Don't output what has been sent to BitBucket."
+    )
 
     auth_group = parser.add_argument_group("Authentication Options")
     auth_group.add_argument("-u", "--user", type=str, required=True, help="User to authenticate with BitBucket")
@@ -152,6 +155,10 @@ def main():
 
     report.post_base_report()
     report.post_annotations()
+
+    if not args.silent:
+        print(report.output_info())
+
     return report.return_code
 
 

--- a/bitbucket_code_insight_reports/report.py
+++ b/bitbucket_code_insight_reports/report.py
@@ -95,3 +95,14 @@ class Report:
         """
         annotations_url = self.url + "/annotations"
         requests.post(annotations_url, json=self.annotations, auth=self.auth)
+
+    def output_info(self):
+        """
+        Returns string with base report and annotation information
+        """
+        report_info = "URL: {url}".format(url=self.url)
+        report_info += "Title: {title}".format(title=self.title)
+        report_info += "Description: {desc}".format(desc=self.description)
+        report_info += "Result: {result}".format(result=self.result)
+        report_info += "Annotations: {annot}".format(annot=json.dumps(self.annotations, indent=4))
+        return report_info

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,6 +44,7 @@ def test_arg_parse():
         "test_file_2",
         "--dict",
         "/some/path/to/dictionary",
+        "--silent",
     ]
 
     parser = cli.parse_args(args)
@@ -63,3 +64,4 @@ def test_arg_parse():
     assert parser.file == "test_file.txt"
     assert parser.file_list == ["test_file_1", "test_file_2"]
     assert parser.dict == "/some/path/to/dictionary"
+    assert parser.silent == True

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -61,3 +61,10 @@ def test_init(
     assert title == test_report.title
     assert description == test_report.description
     assert result == test_report.result
+
+    report_info = "URL: {url}".format(url=test_report_url)
+    report_info += "Title: {title}".format(title=title)
+    report_info += "Description: {desc}".format(desc=description)
+    report_info += "Result: {result}".format(result=result)
+    report_info += "Annotations: {annot}".format(annot=json.dumps(test_annotation, indent=4))
+    assert report_info == test_report.output_info()


### PR DESCRIPTION
Allow the script (by default) to display the information about how and what it is posting to the report.
Disable with the `--silent` flag.