### PR TITLE
fix: Use base dict instead of override

### DIFF
--- a/bitbucket_code_insight_reports/cli.py
+++ b/bitbucket_code_insight_reports/cli.py
@@ -71,7 +71,7 @@ def parse_args(args):
         nargs="+",
         required=False,
         default=[],
-        help="Path to dictionary to include when spell checking",
+        help="Path to dictionaries to include when spell checking",
     )
     spellcheck_filelist_group = spellcheck_report_group.add_mutually_exclusive_group()
     spellcheck_filelist_group.add_argument(
@@ -155,7 +155,7 @@ def main():
             args.report_title,
             args.report_desc,
             files_to_check=files_list,
-            dictionary=args.dict,
+            dictionaries=args.dict,
         )
 
     report.post_base_report()

--- a/bitbucket_code_insight_reports/cli.py
+++ b/bitbucket_code_insight_reports/cli.py
@@ -66,7 +66,12 @@ def parse_args(args):
         "Spellcheck Report Options", description="Arguments only for use with spellcheck report type."
     )
     spellcheck_report_group.add_argument(
-        "--dict", type=str, required=False, default=None, help="Path to dictionary to include when spell checking"
+        "--dict",
+        type=str,
+        nargs="+",
+        required=False,
+        default=[],
+        help="Path to dictionary to include when spell checking",
     )
     spellcheck_filelist_group = spellcheck_report_group.add_mutually_exclusive_group()
     spellcheck_filelist_group.add_argument(

--- a/bitbucket_code_insight_reports/spell_check_report.py
+++ b/bitbucket_code_insight_reports/spell_check_report.py
@@ -25,12 +25,15 @@ class SpellCheckReport(Report):
         title,
         description,
         files_to_check,
-        dictionary=None,
+        dictionaries=None,
     ):  # pylint: disable=too-many-locals
         results = StringIO()
 
+        if dictionaries is None:
+            dictionaries = []
+
         with redirect_stderr(results):
-            return_code = spell_check(files_to_check, report_only=True, base_dicts=dictionary)
+            return_code = spell_check(files_to_check, report_only=True, base_dicts=dictionaries)
 
         annotations_string = results.getvalue().strip()
 

--- a/bitbucket_code_insight_reports/spell_check_report.py
+++ b/bitbucket_code_insight_reports/spell_check_report.py
@@ -30,7 +30,7 @@ class SpellCheckReport(Report):
         results = StringIO()
 
         with redirect_stderr(results):
-            return_code = spell_check(files_to_check, report_only=True, override_dictionary=dictionary)
+            return_code = spell_check(files_to_check, report_only=True, base_dicts=dictionary)
 
         annotations_string = results.getvalue().strip()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -63,5 +63,5 @@ def test_arg_parse():
     assert parser.annotations == "test_annotations"
     assert parser.file == "test_file.txt"
     assert parser.file_list == ["test_file_1", "test_file_2"]
-    assert parser.dict == "/some/path/to/dictionary"
+    assert parser.dict == ["/some/path/to/dictionary"]
     assert parser.silent == True

--- a/tests/test_spell_check_report.py
+++ b/tests/test_spell_check_report.py
@@ -65,7 +65,7 @@ def test_init(word, mock_spellcheck, mock_stringio, gen_scspell_annotation):
         files_to_check=["test/file.cpp", "file3.cpp"],
     )
 
-    assert mock_spellcheck.called_with(["test/file.cpp", "file3.cpp"], report_only=True, override_dictionary=None)
+    assert mock_spellcheck.called_with(["test/file.cpp", "file3.cpp"], report_only=True, base_dicts=None)
 
     assert test_report.result == "FAIL"
     assert test_report.annotations == test_annotations


### PR DESCRIPTION
Initially it seemed like `override-dict` was the correct way to add a dictionary, however it turns out that this *replaces* the dictionaries used by default. Instead `base-dicts` is used to add a dictionary to the existing ones.