### PR TITLE
feat: Add force_pass feature

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -199,7 +199,7 @@ max-spelling-suggestions=4
 spelling-dict=en_US
 
 # List of comma separated words that should not be checked.
-spelling-ignore-words=args, bool, yaml, py, dicts, api, commandline, pragma, terraform, fmt, bitbucket, url, scspell
+spelling-ignore-words=args, bool, yaml, py, dicts, api, commandline, pragma, terraform, fmt, bitbucket, url, scspell, auth, tuple
 
 # A path to a file that contains private dictionary; one word per line.
 spelling-private-dict-file=

--- a/bitbucket_code_insight_reports/cli.py
+++ b/bitbucket_code_insight_reports/cli.py
@@ -26,7 +26,10 @@ def parse_args(args):
         "--silent", action="store_true", default=False, help="Don't output what has been sent to BitBucket."
     )
     parser.add_argument(
-        "--force_pass", action="store_true", default=False, help="Ensure that the report on BitBucket will be passing."
+        "--force_pass",
+        action="store_true",
+        default=False,
+        help="Ensure that the report status on BitBucket can only be passing.",
     )
 
     auth_group = parser.add_argument_group("Authentication Options")

--- a/bitbucket_code_insight_reports/cli.py
+++ b/bitbucket_code_insight_reports/cli.py
@@ -26,10 +26,7 @@ def parse_args(args):
         "--silent", action="store_true", default=False, help="Don't output what has been sent to BitBucket."
     )
     parser.add_argument(
-        "--force_pass",
-        action="store_true",
-        default=False,
-        help="Force the result to pass and the function to return true (for non-blocking CI steps",
+        "--force_pass", action="store_true", default=False, help="Ensure that the report on BitBucket will be passing."
     )
 
     auth_group = parser.add_argument_group("Authentication Options")

--- a/bitbucket_code_insight_reports/cli.py
+++ b/bitbucket_code_insight_reports/cli.py
@@ -25,6 +25,12 @@ def parse_args(args):
     parser.add_argument(
         "--silent", action="store_true", default=False, help="Don't output what has been sent to BitBucket."
     )
+    parser.add_argument(
+        "--force_pass",
+        action="store_true",
+        default=False,
+        help="Force the result to pass and the function to return true (for non-blocking CI steps",
+    )
 
     auth_group = parser.add_argument_group("Authentication Options")
     auth_group.add_argument("-u", "--user", type=str, required=True, help="User to authenticate with BitBucket")
@@ -108,6 +114,7 @@ def main():
             args.report_key,
             args.report_title,
             args.report_desc,
+            force_pass=args.force_pass,
         )
     elif args.report_type == "git-diff":
         if args.file is None:
@@ -123,6 +130,7 @@ def main():
             args.report_title,
             args.report_desc,
             args.file,
+            force_pass=args.force_pass,
         )
     elif args.report_type == "custom":
         report = Report(
@@ -136,6 +144,7 @@ def main():
             args.report_desc,
             args.status,
             args.annotations,
+            force_pass=args.force_pass,
         )
     elif args.report_type == "spell-check":
         if args.file_list:
@@ -154,6 +163,7 @@ def main():
             args.report_key,
             args.report_title,
             args.report_desc,
+            force_pass=args.force_pass,
             files_to_check=files_list,
             dictionaries=args.dict,
         )

--- a/bitbucket_code_insight_reports/git_diff_report.py
+++ b/bitbucket_code_insight_reports/git_diff_report.py
@@ -12,7 +12,9 @@ class GitDiffReport(Report):
     Class to generate a report based on the output of git diff
     """
 
-    def __init__(self, auth, base_url, project_key, repo_slug, commit_id, key, title, description, file_name):
+    def __init__(
+        self, auth, base_url, project_key, repo_slug, commit_id, key, title, description, file_name, force_pass=False
+    ):
         # If there weren't any changes, then its a pass
         if os.stat(file_name).st_size == 0:
             result = "PASS"
@@ -33,6 +35,7 @@ class GitDiffReport(Report):
             result,
             return_code=return_code,
             file_name=file_name,
+            force_pass=False,
         )
 
     def _process_annotations(self, annotations_string):

--- a/bitbucket_code_insight_reports/report.py
+++ b/bitbucket_code_insight_reports/report.py
@@ -69,16 +69,19 @@ class Report:
         if force_pass:
             self.return_code = 0
             self.result = "PASS"
+            return
+
+        self.result = result
+        if return_code:
+            self.return_code = return_code
+            return
+
+        # Determines the return code status if it isn't set, as is the case for checks not directly invoked from this tool
+        if self.result == "PASS":
+            self.return_code = 0
         else:
-            self.result = result
-            # Determines the return code status if it isn't set, as is the case for checks not directly invoked from this tool
-            if return_code is None:
-                if self.result == "PASS":
-                    self.return_code = 0
-                else:
-                    self.return_code = 1
-            else:
-                self.return_code = return_code
+            self.return_code = 1
+        return
 
     @staticmethod
     def _build_base_report_url(base_url, project_key, repo_slug, commit_id, key):

--- a/bitbucket_code_insight_reports/report.py
+++ b/bitbucket_code_insight_reports/report.py
@@ -11,7 +11,7 @@ class Report:
     Generates a basic report for BitBucket Code Insight
     """
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-locals
         self,
         auth,
         base_url,
@@ -25,19 +25,30 @@ class Report:
         annotations_string="",
         return_code=None,
         file_name=None,
+        force_pass=False,
     ):
+        """
+        Sets up the BitBucket code insights report
+        Args:
+            auth: Authentication tuple for BitBucket
+            base_url: base URL for BitBucket
+            project_key: project key in BitBucket for the target PR
+            repo_slug: repository slug (i.e. name in the URL) for the target PR
+            commit_id: commit ID for the target PR
+            key: key to use for the report
+            title: title to use for the report
+            description: description to provide on the report
+            result: result to use for the report (PASS/FAIL)
+            annotations_string: (optional) JSON string of annotations for the report
+            return_code: (Optional) Return code to return from the tool
+            file_name: (Optional) file name to read results from
+            force_pass: (Optional) Boolean, true to force setting the result to PASS and the return_code to 0 (for use in non-blocking CI steps)
+        """
         self.auth = auth
         self.title = title
         self.description = description
-        self.result = result
 
-        if return_code is None:
-            if result == "PASS":
-                self.return_code = 0
-            else:
-                self.return_code = 1
-        else:
-            self.return_code = return_code
+        self._check_return_and_result(force_pass, return_code, result)
 
         if file_name is not None:
             with open(file_name, mode="r") as report_file:
@@ -45,6 +56,29 @@ class Report:
 
         self.url = self._build_base_report_url(base_url, project_key, repo_slug, commit_id, key)
         self.annotations = self._process_annotations(annotations_string)
+
+    def _check_return_and_result(self, force_pass, return_code, result):
+        """
+        Determine what needs to be set for return_code (which is what the tool itself should return to the calling function) and what should be set
+        for result (which is what is posted to BitBucket).
+        Args:
+            force_pass: bool to indicate that everything should be set to passing and the tool should return 0
+            return_code: int
+        """
+        # This allows the user to force everything to pass, as for a non-blocking CI step
+        if force_pass:
+            self.return_code = 0
+            self.result = "PASS"
+        else:
+            self.result = result
+            # Determines the return code status if it isn't set, as is the case for checks not directly invoked from this tool
+            if return_code is None:
+                if self.result == "PASS":
+                    self.return_code = 0
+                else:
+                    self.return_code = 1
+            else:
+                self.return_code = return_code
 
     @staticmethod
     def _build_base_report_url(base_url, project_key, repo_slug, commit_id, key):

--- a/bitbucket_code_insight_reports/report.py
+++ b/bitbucket_code_insight_reports/report.py
@@ -37,12 +37,12 @@ class Report:
             commit_id: commit ID for the target PR
             key: key to use for the report
             title: title to use for the report
-            description: description to provide on the report
+            description: description to provide for the report
             result: result to use for the report (PASS/FAIL)
             annotations_string: (optional) JSON string of annotations for the report
-            return_code: (Optional) Return code to return from the tool
-            file_name: (Optional) file name to read results from
-            force_pass: (Optional) Boolean, true to force setting the result to PASS and the return_code to 0 (for use in non-blocking CI steps)
+            return_code: (optional) return code to return from the tool
+            file_name: (optional) file name to read results from
+            force_pass: (optional) Boolean, true to force setting the result to PASS and the return_code to 0 (for use in non-blocking CI steps)
         """
         self.auth = auth
         self.title = title

--- a/bitbucket_code_insight_reports/spell_check_report.py
+++ b/bitbucket_code_insight_reports/spell_check_report.py
@@ -26,6 +26,7 @@ class SpellCheckReport(Report):
         description,
         files_to_check,
         dictionaries=None,
+        force_pass=False,
     ):  # pylint: disable=too-many-locals
         results = StringIO()
 
@@ -53,6 +54,7 @@ class SpellCheckReport(Report):
             description,
             result,
             annotations_string=annotations_string,
+            force_pass=force_pass,
         )
 
     @staticmethod

--- a/bitbucket_code_insight_reports/terraform_report.py
+++ b/bitbucket_code_insight_reports/terraform_report.py
@@ -14,7 +14,17 @@ class TerraformReport(Report):
     """
 
     def __init__(
-        self, auth, base_url, project_key, repo_slug, commit_id, key, title, description, file_name=None
+        self,
+        auth,
+        base_url,
+        project_key,
+        repo_slug,
+        commit_id,
+        key,
+        title,
+        description,
+        file_name=None,
+        force_pass=False,
     ):  # pylint: disable=too-many-locals
         annotations_string = ""
         if file_name is None:
@@ -40,6 +50,7 @@ class TerraformReport(Report):
             result,
             annotations_string=annotations_string,
             return_code=return_code,
+            force_pass=force_pass,
         )
 
     @staticmethod

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -68,3 +68,25 @@ def test_init(
     report_info += "Result: {result}\n".format(result=result)
     report_info += "Annotations: {annot}\n".format(annot=json.dumps(test_annotation, indent=4, sort_keys=True))
     assert report_info == test_report.output_info()
+
+
+def test_force_pass(gen_annotations):
+    """
+    Ensure that using `force_pass` in initialization will make everything return passing
+    """
+    test_report = Report(
+        "test",
+        "test",
+        "test",
+        "test",
+        "test",
+        "test",
+        "test",
+        "test",
+        False,
+        json.dumps(gen_annotations("/test", 3, "test")),
+        return_code=1,
+        force_pass=True,
+    )
+    assert test_report.result == "PASS"
+    assert test_report.return_code == 0


### PR DESCRIPTION
By adding a CLI option to force the everything to pass, we can have non-blocking builds (such as spell check) add annotations without showing as failing on the BitBucket PR.